### PR TITLE
Add github actions and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+.idea
+README.md
+.gitignore
+.github

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install clang llvm pkg-config nettle-dev
+      - run: rustup update stable && rustup default stable
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,70 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value={{date 'YYYYMMDD-hhmmss' tz='Europe/Berlin'}}
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:latest as build-stage
+
+COPY Cargo.lock .
+COPY Cargo.toml .
+
+RUN apt-get -y update && apt-get -y install clang llvm pkg-config nettle-dev
+
+COPY src ./src
+RUN set -x && cargo build --release
+
+# Create a minimal docker image 
+FROM debian:bullseye-slim
+
+ENV RUST_LOG="error,wkd-server=info"
+COPY --from=build-stage /target/release/wkd-server /wkd-server
+
+EXPOSE 8080
+
+VOLUME /openpgp-keys
+CMD ["/wkd-server", "/openpgp-keys"]

--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ Options:
 This server will refuse to serve private or invalid keys.
 If a file contains a private and a public key, only the public key will be served.
 Nonetheless, make sure to only include your public key.
+
+### Deployment
+
+You can use this `docker-compose.yaml` example file as a starting off point for your
+deployment. Make sure to add your public keys as a volume.
+
+```
+services:
+    wkd-server:
+        image: ghcr.io/martin-fink/rust-wkd-server:latest
+        volumes:
+            - ./keys:/openpgp-keys:ro
+        ports:
+            - 127.0.0.1:8080:8080
+```


### PR DESCRIPTION
This PR adds workflows to automatically build and test on each commit and publish an easily deployable docker image of the server that gets automatically released on changes to the main branch.