### PR TITLE
use chainguard images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
-FROM rust:latest as build-stage
+FROM cgr.dev/chainguard/rust:latest as build
 
-WORKDIR /build
+WORKDIR /work
 
-COPY Cargo.toml Cargo.lock /build/
+COPY Cargo.toml Cargo.lock .
 
-RUN mkdir /build/src && echo "fn main() {}" > /build/src/main.rs
+RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # cache dependencies
 RUN cargo build --release
 
-COPY src ./src
-
+COPY --chown=nonroot:nonroot src src
 # make sure main.rs is rebuilt
-RUN touch /build/src/main.rs
+RUN touch src/main.rs
 RUN cargo build --release
 
 # Create a minimal docker image
-FROM debian:stable-slim
+FROM cgr.dev/chainguard/glibc-dynamic
 
 ENV RUST_LOG="error,wkd_server=info"
-COPY --from=build-stage /build/target/release/wkd-server /wkd-server
+COPY --from=build --chown=nonroot:nonroot /work/target/release/wkd-server  /usr/local/bin/
 
 EXPOSE 8080
 
 VOLUME /openpgp-keys
-CMD ["/wkd-server", "/openpgp-keys"]
+CMD ["/usr/local/bin/wkd-server", "/openpgp-keys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM cgr.dev/chainguard/rust:latest as build
+FROM rust:latest as build
 
-WORKDIR /work
+WORKDIR /build
 
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # cache dependencies
 RUN cargo build --release
 
-COPY --chown=nonroot:nonroot src src
+COPY src ./src
+
 # make sure main.rs is rebuilt
 RUN touch src/main.rs
 RUN cargo build --release
@@ -18,7 +19,7 @@ RUN cargo build --release
 FROM cgr.dev/chainguard/glibc-dynamic
 
 ENV RUST_LOG="error,wkd_server=info"
-COPY --from=build --chown=nonroot:nonroot /work/target/release/wkd-server  /usr/local/bin/
+COPY --from=build --chown=nonroot:nonroot /build/target/release/wkd-server /usr/local/bin/
 
 EXPOSE 8080
 


### PR DESCRIPTION
Chainguard Images are regularly-updated, minimal container images with low-to-zero CVEs. The size of the is image only 17.3 MB

```
# podman images ghcr.io/martin-fink/rust-wkd-server:latest
REPOSITORY                           TAG         IMAGE ID      CREATED      SIZE
ghcr.io/martin-fink/rust-wkd-server  latest      7f9f421e6503  5 weeks ago  107 MB
# podman images localhost/rust-wkd-server:latest
REPOSITORY                 TAG         IMAGE ID      CREATED         SIZE
localhost/rust-wkd-server  latest      d8a8d45e6be9  28 minutes ago  17.3 MB
```