### PR TITLE
feat: Extract user ids from certificate instead of filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,10 @@ https://wiki.gnupg.org/WKD
 ## Running this project
 
 Put your **public** keys into `./openpgp/keys`.
-Files should be named after the email address that the key is registered for.
-See some examples below:
-
-- Valid names:
-  - `user@example.com`
-  - `user@example.com.asc` (optional `.asc` file ending will be ignored)
-- Invalid names:
-  - `ktujkt7nrz91b17es7prizffedzxrsna` (wkd hash -- this tool will hash the username)
-  - `my-public-key.asc`
+The name of the file does not matter, this service extracts all user ids and serves them.
+By default, every key in the directory is loaded and all associated user IDs are made available via the API.
+You can restrict responses to a specific user ID by enabling the `--split-keys` option or setting the `SPLIT_KEYS=true`
+environment variable. In this mode, each request will only return the matching user ID and its corresponding key.
 
 Optionally, put your policy into a text file in `./openpgp`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,12 +7,21 @@ pub struct Config {
     /// The path where the GPG keys are stored
     pub keys_path: String,
     #[clap(long, env, default_value = "0.0.0.0")]
+    /// Address to bind the HTTP server to.
+    /// Defaults to 0.0.0.0 to listen on all interfaces.
     pub address: String,
     #[clap(long, env, default_value = "8080")]
+    /// Port to bind the HTTP server to.
+    /// Defaults to 8080.
     pub port: String,
     /// The path to the policy file. If not set, an empty policy is served.
     #[clap(long, short, env)]
     pub policy: Option<String>,
+    #[clap(long, env)]
+    /// Split certificate into individual user IDs.
+    /// If set, only the requested user ID and corresponding key will be returned from the certificate.
+    /// Otherwise, the response will include all user IDs and keys found in the file.
+    pub split_keys: bool,
 }
 
 impl Config {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -25,7 +25,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let socket_addr: SocketAddr = format!("{}:{}", config.address, config.port)
         .as_str()
         .parse()?;
-    let cache = KeyDb::new(Path::new(&config.keys_path)).await?;
+    let cache = KeyDb::new(Path::new(&config.keys_path), config.split_keys).await?;
     let app = api_router()
         .with_state(ApiContext {
             config: Arc::new(config),

--- a/src/keys/hash.rs
+++ b/src/keys/hash.rs
@@ -1,0 +1,111 @@
+use crate::keys::db::CertKey;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use sha1::{Digest, Sha1};
+
+/// Match any text that has one @ sign and split at the @ sign
+/// Trailing optional .asc is not included in the domain. See some examples below.
+///
+/// Will be included:
+/// ```
+/// user@example.com
+/// user2@example.com.asc
+/// ```
+///
+/// Will not be included:
+/// ```
+/// ktujkt7nrz91b17es7prizffedzxrsna
+/// my-public-key.asc
+/// ```
+static FILE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([^@]+)@([^@]+?)(?:\.asc)?$").unwrap());
+
+pub fn mail_to_key_entry(email: &str) -> anyhow::Result<Option<(String, CertKey)>> {
+    let Some(captures) = FILE_REGEX.captures(email) else {
+        return Ok(None);
+    };
+
+    // Unwrap is ok here, as we know the regex
+    let username = captures.get(1).unwrap().as_str();
+    let hashed_username = hash_file_name(username);
+    let host = captures.get(2).unwrap().as_str();
+
+    let key = CertKey {
+        hashed_username,
+        domain: host.to_string(),
+    };
+
+    Ok(Some((username.into(), key)))
+}
+
+fn hash_file_name(name: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(name.as_bytes());
+    let result = hasher.finalize();
+    zbase32::encode_full_bytes(&result[..])
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::keys::db::CertKey;
+    use crate::keys::hash::mail_to_key_entry;
+
+    #[test]
+    fn file_to_entry() {
+        assert_eq!(
+            mail_to_key_entry("m@example.com").unwrap().unwrap(),
+            (
+                "m".to_string(),
+                CertKey {
+                    hashed_username: "pcgudogicctdyjg4eiwtmbdr8mda3fze".to_string(),
+                    domain: "example.com".to_string()
+                }
+            )
+        );
+        assert_eq!(
+            mail_to_key_entry("hello.world@domain").unwrap().unwrap(),
+            (
+                "hello.world".to_string(),
+                CertKey {
+                    hashed_username: "nsaw3ax9dxhjee85afxziy7i79oxx6rh".to_string(),
+                    domain: "domain".to_string()
+                }
+            )
+        );
+        assert_eq!(
+            mail_to_key_entry("hello.world@sub.domain-asdf.com")
+                .unwrap()
+                .unwrap(),
+            (
+                "hello.world".to_string(),
+                CertKey {
+                    hashed_username: "nsaw3ax9dxhjee85afxziy7i79oxx6rh".to_string(),
+                    domain: "sub.domain-asdf.com".to_string()
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn file_path_absolute() {
+        assert_eq!(
+            mail_to_key_entry("hello.world@domain").unwrap().unwrap(),
+            (
+                "hello.world".to_string(),
+                CertKey {
+                    hashed_username: "nsaw3ax9dxhjee85afxziy7i79oxx6rh".to_string(),
+                    domain: "domain".to_string()
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn file_path_empty() {
+        assert!(mail_to_key_entry("/").unwrap().is_none());
+    }
+
+    #[test]
+    fn file_invalid_name() {
+        assert!(mail_to_key_entry("hello@asd@ts@@@").unwrap().is_none());
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,4 +1,5 @@
 mod db;
 mod fs;
+mod hash;
 
 pub use db::KeyDb;


### PR DESCRIPTION
This also adds a new flag `--split-keys`, that enables serving just the key matching the requested user id instead of all user ids. This is disabled by default. Suggested by @kaaax0815. Thanks!

Closes #272.