### PR TITLE
feat!: add support for multiple policies per domain, advanced mode for policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@ Arguments:
   <KEYS_PATH>  The path where the GPG keys are stored
 
 Options:
-      --address <ADDRESS>  [env: ADDRESS=] [default: 0.0.0.0]
-      --port <PORT>        [env: PORT=] [default: 8080]
-  -p, --policy <POLICY>    The path to the policy file. If not set, an empty policy is served [env: POLICY=]
+      --address <ADDRESS>  Address to bind the HTTP server to. Defaults to 0.0.0.0 to listen on all interfaces [env: ADDRESS=] [default: 0.0.0.0]
+      --port <PORT>        Port to bind the HTTP server to. Defaults to 8080 [env: PORT=] [default: 8080]
+  -p, --policy <POLICY>    The path to the policy directory. If not set, an empty policy is served [env: POLICY=]
+      --split-keys         Split certificate into individual user IDs. If set, only the requested user ID and corresponding key will be returned from the certificate. Otherwise, the response will include all user IDs and keys found in the file [env: SPLIT_KEYS=]
   -h, --help               Print help
 ```
+
+### Policy
+
+The policy directory can contain the following files:
+- `default`: This is the default policy served for all domains, if no more specific policy can be found.
+- `$domain`: This is the policy that should be served for a specific domain. Example: `example.com`.
 
 ### Security
 

--- a/openpgp/policy/default
+++ b/openpgp/policy/default
@@ -1,0 +1,1 @@
+# This is the default policy asd

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
     /// Port to bind the HTTP server to.
     /// Defaults to 8080.
     pub port: String,
-    /// The path to the policy file. If not set, an empty policy is served.
+    /// The path to the policy directory. If not set, an empty policy is served.
     #[clap(long, short, env)]
     pub policy: Option<String>,
     #[clap(long, env)]
@@ -39,8 +39,8 @@ impl Config {
 
         if let Some(policy) = &self.policy {
             let policy_path = Path::new(policy);
-            if !policy_path.exists() || policy_path.is_dir() {
-                return Err(anyhow!("Policy '{}' is not a file.", policy));
+            if !policy_path.exists() || !policy_path.is_dir() {
+                return Err(anyhow!("Policy directory '{}' is not a directory.", policy));
             }
         }
 

--- a/src/http/policy.rs
+++ b/src/http/policy.rs
@@ -1,21 +1,43 @@
 use crate::http::errors::ApiError;
 use crate::http::ApiContext;
-use axum::extract::State;
+use crate::policy::get_policy;
+use axum::extract::{Path, State};
 use axum::routing::get;
 use axum::Router;
-use std::fs;
+use axum_extra::extract::Host;
 
 type PolicyResponse = String;
 
 const EMPTY_POLICY: &str = "# Empty policy\n";
 
-pub async fn get_policy(State(state): State<ApiContext>) -> Result<PolicyResponse, ApiError> {
+fn get_policy_for_domain(state: &ApiContext, domain: &str) -> Result<PolicyResponse, ApiError> {
     match &state.config.policy {
         None => Ok(EMPTY_POLICY.into()),
-        Some(path) => fs::read_to_string(path).map_err(|_| ApiError::Internal("".into())),
+        Some(path) => Ok(get_policy(path, domain)
+            .map_err(|_| ApiError::Internal("".into()))?
+            .unwrap_or_default()),
     }
 }
 
+pub async fn get_policy_direct(
+    State(state): State<ApiContext>,
+    Host(domain): Host,
+) -> Result<PolicyResponse, ApiError> {
+    get_policy_for_domain(&state, &domain)
+}
+
+pub async fn get_policy_advanced(
+    State(state): State<ApiContext>,
+    Path(domain): Path<String>,
+) -> Result<PolicyResponse, ApiError> {
+    get_policy_for_domain(&state, &domain)
+}
+
 pub fn router() -> Router<ApiContext> {
-    Router::new().route("/.well-known/openpgpkey/policy", get(get_policy))
+    Router::new()
+        .route("/.well-known/openpgpkey/policy", get(get_policy_direct))
+        .route(
+            "/.well-known/openpgpkey/{domain}/policy",
+            get(get_policy_advanced),
+        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 mod config;
 mod http;
 mod keys;
+mod policy;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/src/policy/fs.rs
+++ b/src/policy/fs.rs
@@ -1,0 +1,32 @@
+use std::{fs, io};
+use tracing::error;
+
+pub fn get_policy(policy_dir: &str, domain: &str) -> Result<Option<String>, io::Error> {
+    if !fs::exists(policy_dir)? {
+        error!("policy dir {} does not exist", policy_dir);
+        return Ok(None);
+    }
+
+    // first, we check if the domain policy exists.
+    let path = format!("{policy_dir}/{domain}");
+    let policy = try_read_policy(&path)?;
+    if policy.is_some() {
+        return Ok(policy);
+    }
+
+    // otherwise, we try to serve the default policy.
+    let path = format!("{policy_dir}/default");
+    let policy = try_read_policy(&path)?;
+
+    Ok(policy)
+}
+
+fn try_read_policy(domain_policy: &str) -> Result<Option<String>, io::Error> {
+    let result = if fs::exists(domain_policy)? {
+        Some(fs::read_to_string(domain_policy)?)
+    } else {
+        None
+    };
+
+    Ok(result)
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,0 +1,3 @@
+mod fs;
+
+pub use fs::*;


### PR DESCRIPTION
Closes #279.

This is a breaking change, as the policy flag now points to a directory containing the policy, instead of the policy file directly.